### PR TITLE
fix: header logo overflow

### DIFF
--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import {footerRoutes} from "@/lib/routes";
-import {hoverShadow, sponsors} from "@/lib/sponsors";
+import {sponsors} from "@/lib/sponsors";
 import {ExternalLinkIcon} from "@radix-ui/react-icons";
 import cn from "classnames";
 import {useSession} from "next-auth/react";
@@ -20,7 +20,7 @@ const Footer = ({className}: FooterProps) => {
         id="svg"
         viewBox="0 0 1440 390"
         xmlns="http://www.w3.org/2000/svg"
-        className="h-40 w-full min-w-[1000px] transition delay-150 duration-300 ease-in-out"
+        className="h-40 w-full transition delay-150 duration-300 ease-in-out"
         preserveAspectRatio="none"
       >
         <path
@@ -90,26 +90,13 @@ const Footer = ({className}: FooterProps) => {
             <div>
               <h3 className="mb-4 py-2 text-xl font-bold">🔧 Powered by</h3>
               <ul className="space-y-5">
-                {sponsors.map(({label, href, imageSrc}) => {
-                  const shadowColor = hoverShadow[label];
-
-                  return (
-                    <li key={label}>
-                      <Link href={href} target="_blank" rel="noreferrer">
-                        <Image
-                          src={imageSrc}
-                          className={cn(
-                            "rounded-lg bg-white px-5 py-3 shadow-md transition-shadow duration-300 ease-in-out",
-                            shadowColor,
-                          )}
-                          height={150}
-                          width={150}
-                          alt={`${label} logo`}
-                        />
-                      </Link>
-                    </li>
-                  );
-                })}
+                {sponsors.map(({label, href, imageSrc}) => (
+                  <li key={label}>
+                    <Link href={href} target="_blank" rel="noreferrer">
+                      <Image src={imageSrc} height={150} width={150} alt={`${label} logo`} />
+                    </Link>
+                  </li>
+                ))}
               </ul>
             </div>
           </div>

--- a/apps/web/src/components/header-logo.tsx
+++ b/apps/web/src/components/header-logo.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import cn from "classnames";
 import {getDate, getHours, getMonth, getWeek, isFriday, isMonday, isThursday} from "date-fns";
 import {nb} from "date-fns/locale";
-import {motion} from "framer-motion";
 
 const randomHeaderMessage = () => {
   const now = new Date();
@@ -68,12 +67,11 @@ const randomHeaderMessage = () => {
   return stdMessages()[Math.floor(Math.random() * stdMessages().length)];
 };
 
-type HeaderLogoProps = {
+type Props = {
   className?: string;
-  isShrunk: boolean;
 };
 
-const HeaderLogo = ({className, isShrunk}: HeaderLogoProps) => {
+const HeaderLogo = ({className}: Props) => {
   const [_headerMessage, setHeaderMessage] = useState("");
 
   useEffect(() => {
@@ -88,17 +86,9 @@ const HeaderLogo = ({className, isShrunk}: HeaderLogoProps) => {
   const logo = "/images/android-chrome-512x512.png";
 
   return (
-    <div className={cn(className)}>
-      <Link href="/" className="flex items-center gap-5">
-        <motion.div
-          style={{
-            height: isShrunk ? 50 : 100,
-            width: isShrunk ? 50 : 100,
-          }}
-          className="relative h-20 w-20 origin-right transition-all duration-300 ease-in-out md:h-24 md:w-24"
-        >
-          <Image src={logo} alt="logo" fill />
-        </motion.div>
+    <div className={cn("relative aspect-square h-full w-full", className)}>
+      <Link href="/">
+        <Image src={logo} alt="logo" fill />
       </Link>
     </div>
   );

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -1,8 +1,5 @@
-import {useEffect, useState, type ReactNode} from "react";
-import {fetchBanner} from "@/api/banner";
-import {type Banner} from "@/api/banner/schemas";
+import {type ReactNode} from "react";
 
-import WebsiteBanner from "./banner";
 import Footer from "./footer";
 import Header from "./header";
 
@@ -11,21 +8,9 @@ type LayoutProps = {
 };
 
 const Layout = ({children}: LayoutProps) => {
-  const [banner, setBanner] = useState<Banner | null>(null);
-
-  useEffect(() => {
-    const setBannerMessage = async () => {
-      const banner = await fetchBanner();
-      setBanner(banner);
-    };
-
-    void setBannerMessage();
-  }, []);
-
   return (
     <>
       <div className="flex min-h-screen flex-col bg-white">
-        <WebsiteBanner banner={banner} />
         <Header />
         <main className="my-10">{children}</main>
         <Footer className="mt-auto" />

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -15,6 +15,21 @@ import nb from "date-fns/locale/nb";
 import {motion} from "framer-motion";
 import removeMd from "remove-markdown";
 
+const container = {
+  hidden: {opacity: 0},
+  show: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+      delayChildren: 0.25,
+    },
+  },
+};
+const avatarImageVariants = {
+  hidden: {y: "100%"},
+  show: {y: "0%"},
+};
+
 type Props = {
   eventPreviews: Awaited<ReturnType<typeof fetchComingEventPreviews>>;
   bedpresPreviews: Awaited<ReturnType<typeof fetchComingEventPreviews>>;
@@ -23,22 +38,7 @@ type Props = {
   board: Awaited<ReturnType<typeof fetchStudentGroupBySlug>>;
 };
 
-const HomePage: React.FC<Props> = ({eventPreviews, bedpresPreviews, posts, jobAds, board}) => {
-  const container = {
-    hidden: {opacity: 0},
-    show: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1,
-        delayChildren: 0.25,
-      },
-    },
-  };
-  const avatarImageVariants = {
-    hidden: {y: "100%"},
-    show: {y: "0%"},
-  };
-
+const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props) => {
   return (
     <>
       <Head>

--- a/apps/web/src/utils/animations/parallax.tsx
+++ b/apps/web/src/utils/animations/parallax.tsx
@@ -3,13 +3,13 @@ import {motion, useScroll} from "framer-motion";
 
 import {useParallax} from "./helpers";
 
-interface ParallaxProps {
+type ParallaxProps = {
   slowElement: ReactNode;
   fastElement: ReactNode;
   speed?: number;
-}
+};
 
-export const Parallax: React.FC<ParallaxProps> = ({slowElement, fastElement, speed}) => {
+export const Parallax = ({slowElement, fastElement, speed}: ParallaxProps) => {
   const target = useRef(null);
   const {scrollYProgress} = useScroll({target});
   const y = useParallax(scrollYProgress, speed ? speed : 300);


### PR DESCRIPTION
- Fikser logo overflow.
- Fjerner bakgrunn på "Powered by" i footer. Shadow funket ikke og kanskje litt stygt / passer ikke.
- Flytter variants til `framer-motion` fra lokal scope til global.
- Flytter `WebsiteBanner` fra `Layout` til `Header`
- Ender `isShrunk` til `hasScrolled`. Tenker det er bedre navn siden variabelnavnet sier mer om hva som skal skje og ikke hva som har skjedd.
- Fikser også footer overflow greia, men nå blir bølgene mer "skarp".

Fikk ikke til å fikse avatar greia uten å fjerne animasjonen.