### PR TITLE
fix: header logo animation and rounded avatar images

### DIFF
--- a/apps/web/src/components/avatar.tsx
+++ b/apps/web/src/components/avatar.tsx
@@ -20,7 +20,7 @@ const AvatarImage = React.forwardRef<
 >(({className, ...props}, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn("h-full w-full rounded-full", className)}
     {...props}
   />
 ));

--- a/apps/web/src/components/avatar.tsx
+++ b/apps/web/src/components/avatar.tsx
@@ -20,7 +20,7 @@ const AvatarImage = React.forwardRef<
 >(({className, ...props}, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("h-full w-full rounded-full", className)}
+    className={cn("aspect-square h-full w-full rounded-full", className)}
     {...props}
   />
 ));

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -30,7 +30,6 @@ const Header = () => {
         if (current && document.body.scrollTop < 5 && document.documentElement.scrollTop < 5) {
           return false;
         }
-
         return current;
       });
     };
@@ -62,9 +61,10 @@ const Header = () => {
       >
         <motion.div
           style={{
-            opacity: hasScrolled ? 0 : 1,
+            height: hasScrolled ? 40 : 75,
+            width: hasScrolled ? 40 : 75,
           }}
-          className="h-20 w-20 transition-opacity duration-100"
+          className="h-20 w-20 transition-all duration-150 ease-in-out"
         >
           <HeaderLogo />
         </motion.div>

--- a/apps/web/src/pages/event/[slug].tsx
+++ b/apps/web/src/pages/event/[slug].tsx
@@ -20,7 +20,7 @@ const EventPage = ({event}: Props) => {
           <Breadcrumbs.Item>{event.title}</Breadcrumbs.Item>
         </Breadcrumbs>
 
-        <div className="mb-5 flex flex-col gap-3 border-b border-t py-3">
+        <div className="sticky top-14 mb-5 flex flex-col gap-3 border-b border-t bg-white py-3">
           <div className="flex w-full items-center">
             <div>
               <p>

--- a/apps/web/src/pages/for-students/subgroup/index.tsx
+++ b/apps/web/src/pages/for-students/subgroup/index.tsx
@@ -7,6 +7,7 @@ import {
 import Container from "@/components/container";
 import Layout from "@/components/layout";
 import {isErrorMessage} from "@/utils/error";
+import {motion} from "framer-motion";
 
 const GROUP_TYPE: StudentGroupType = "subgroup";
 const TITLE = "Undergrupper";
@@ -24,9 +25,22 @@ const SubGroupsPage = ({groups}: Props) => {
 
           <ul className="flex flex-col gap-3">
             {groups.map((group) => (
-              <li key={group.slug}>
-                <Link href={`/for-students/${GROUP_TYPE}/${group.slug}`}>Les om, {group.name}</Link>
-              </li>
+              <div className="overflow-hidden" key={group.slug}>
+                <motion.li
+                  initial={{y: "150%"}}
+                  animate={{y: "0%"}}
+                  transition={{
+                    type: "spring",
+                    stiffness: 250,
+                    damping: 20,
+                    duration: 1.5,
+                  }}
+                >
+                  <Link href={`/for-students/${GROUP_TYPE}/${group.slug}`}>
+                    Les om, {group.name}
+                  </Link>
+                </motion.li>
+              </div>
             ))}
           </ul>
         </Container>

--- a/apps/web/src/pages/for-students/suborg/index.tsx
+++ b/apps/web/src/pages/for-students/suborg/index.tsx
@@ -7,6 +7,7 @@ import {
 import Container from "@/components/container";
 import Layout from "@/components/layout";
 import {isErrorMessage} from "@/utils/error";
+import {motion} from "framer-motion";
 
 const GROUP_TYPE: StudentGroupType = "suborg";
 const TITLE = "Underorganisasjoner";
@@ -24,9 +25,22 @@ const SubOrgsPage = ({groups}: Props) => {
 
           <ul className="flex flex-col gap-3">
             {groups.map((group) => (
-              <li key={group.slug}>
-                <Link href={`/for-students/${GROUP_TYPE}/${group.slug}`}>Les om, {group.name}</Link>
-              </li>
+              <div className="overflow-hidden" key={group.slug}>
+                <motion.li
+                  initial={{y: "150%"}}
+                  animate={{y: "0%"}}
+                  transition={{
+                    type: "spring",
+                    stiffness: 250,
+                    damping: 20,
+                    duration: 1.5,
+                  }}
+                >
+                  <Link href={`/for-students/${GROUP_TYPE}/${group.slug}`}>
+                    Les om, {group.name}
+                  </Link>
+                </motion.li>
+              </div>
             ))}
           </ul>
         </Container>

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -97,7 +97,9 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
 
           {/* Posts */}
           <section className="flex flex-col gap-5 rounded-md border p-5 lg:col-span-2">
-            <h2 className="text-center text-3xl font-semibold">Siste nytt</h2>
+            <Link href={"/for-students/post"}>
+              <h2 className="text-center text-3xl font-semibold">Siste nytt</h2>
+            </Link>
             <hr />
             <ul className="grid grid-cols-1 gap-x-3 gap-y-5 lg:grid-cols-2">
               {posts.map((post) => {
@@ -140,7 +142,9 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
 
           {/* Job ads */}
           <section className="flex flex-col gap-5 rounded-md border p-5 lg:col-span-2">
-            <h2 className="text-center text-3xl font-semibold">Jobbannonser</h2>
+            <Link href={"/for-students/job"}>
+              <h2 className="text-center text-3xl font-semibold">Jobbannonser</h2>
+            </Link>
             <hr />
             <ul className="grid grid-cols-1 gap-x-3 gap-y-5 lg:grid-cols-2">
               {jobAds.map((jobAd) => (
@@ -199,7 +203,9 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
           {/* Board */}
           {!isErrorMessage(board) && (
             <section className="flex flex-col gap-5 rounded-md border p-5 lg:col-span-2">
-              <h2 className="text-center text-3xl font-semibold">Hovedstyret</h2>
+              <Link href={"/for-students/board"}>
+                <h2 className="text-center text-3xl font-semibold">Hovedstyret</h2>
+              </Link>
               <hr />
               <motion.ul
                 variants={container}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -35,7 +35,7 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
         <div className="container mx-auto grid grid-cols-1 gap-y-12 gap-x-5 px-3 lg:grid-cols-2">
           {/* Events  */}
           <section className="flex flex-col gap-5 rounded-md border p-5">
-            <Link href={"/event"} className="min-h-[2.5rem] overflow-hidden">
+            <Link href="/event" className="min-h-[2.5rem] overflow-hidden">
               <motion.h2
                 initial={{y: "100%"}}
                 animate={{y: "0%"}}
@@ -59,7 +59,7 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
 
           {/* Bedpresses */}
           <section className="flex flex-col gap-5 rounded-md border p-5">
-            <Link href={"/event"} className="min-h-[2.5rem] overflow-hidden">
+            <Link href="/event" className="min-h-[2.5rem] overflow-hidden">
               <motion.h2
                 initial={{y: "100%"}}
                 animate={{y: "0%"}}
@@ -83,7 +83,7 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
 
           {/* Posts */}
           <section className="flex flex-col gap-5 rounded-md border p-5 lg:col-span-2">
-            <Link href={"/for-students/post"}>
+            <Link href="/for-students/post">
               <h2 className="text-center text-3xl font-semibold">Siste nytt</h2>
             </Link>
             <hr />
@@ -128,7 +128,7 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
 
           {/* Job ads */}
           <section className="flex flex-col gap-5 rounded-md border p-5 lg:col-span-2">
-            <Link href={"/for-students/job"}>
+            <Link href="/for-students/job">
               <h2 className="text-center text-3xl font-semibold">Jobbannonser</h2>
             </Link>
             <hr />
@@ -189,7 +189,7 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
           {/* Board */}
           {!isErrorMessage(board) && (
             <section className="flex flex-col gap-5 rounded-md border p-5 lg:col-span-2">
-              <Link href={"/for-students/board"}>
+              <Link href="/for-students/board">
                 <h2 className="text-center text-3xl font-semibold">Hovedstyret</h2>
               </Link>
               <hr />
@@ -197,6 +197,7 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
                 variants={staggeredListContainer}
                 initial="hidden"
                 whileInView="show"
+                viewport={{once: true}}
                 className="grid grid-cols-1 gap-x-3 gap-y-5 md:grid-cols-2 lg:grid-cols-3"
               >
                 {board.members.map((member) => (

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -8,27 +8,13 @@ import {fetchStudentGroupBySlug} from "@/api/student-group";
 import {Avatar, AvatarFallback, AvatarImage} from "@/components/avatar";
 import EventPreviewBox from "@/components/event-preview";
 import Layout from "@/components/layout";
+import {staggeredListContainer, verticalStaggeredChildren} from "@/utils/animations/helpers";
 import {isErrorMessage} from "@/utils/error";
 import cn from "classnames";
 import {format} from "date-fns";
 import nb from "date-fns/locale/nb";
 import {motion} from "framer-motion";
 import removeMd from "remove-markdown";
-
-const container = {
-  hidden: {opacity: 0},
-  show: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-      delayChildren: 0.25,
-    },
-  },
-};
-const avatarImageVariants = {
-  hidden: {y: "100%"},
-  show: {y: "0%"},
-};
 
 type Props = {
   eventPreviews: Awaited<ReturnType<typeof fetchComingEventPreviews>>;
@@ -208,7 +194,7 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
               </Link>
               <hr />
               <motion.ul
-                variants={container}
+                variants={staggeredListContainer}
                 initial="hidden"
                 whileInView="show"
                 className="grid grid-cols-1 gap-x-3 gap-y-5 md:grid-cols-2 lg:grid-cols-3"
@@ -217,7 +203,7 @@ const HomePage = ({eventPreviews, bedpresPreviews, posts, jobAds, board}: Props)
                   <li key={member.profile.name}>
                     <div className="flex h-full flex-col items-center gap-5 p-5">
                       <Avatar className="overflow-hidden border">
-                        <motion.div variants={avatarImageVariants}>
+                        <motion.div variants={verticalStaggeredChildren}>
                           <AvatarImage
                             src={member.profile.imageUrl ?? ""}
                             alt={`${member.profile.name} profilbilde`}

--- a/apps/web/src/utils/animations/helpers.ts
+++ b/apps/web/src/utils/animations/helpers.ts
@@ -1,5 +1,28 @@
 import {useTransform, type MotionValue} from "framer-motion";
 
+// functions
 export const useParallax = (value: MotionValue<number>, distance: number) => {
   return useTransform(value, [0, 1], [-distance, distance]);
+};
+
+// variants
+export const staggeredListContainer = {
+  hidden: {opacity: 0},
+  show: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.25,
+      delayChildren: 0.1,
+    },
+  },
+};
+
+export const horizontalStaggeredChildren = {
+  hidden: {x: "-100%"},
+  show: {x: "0%"},
+};
+
+export const verticalStaggeredChildren = {
+  hidden: {y: "100%"},
+  show: {y: "0%"},
 };

--- a/apps/web/src/utils/animations/helpers.ts
+++ b/apps/web/src/utils/animations/helpers.ts
@@ -11,8 +11,8 @@ export const staggeredListContainer = {
   show: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.25,
-      delayChildren: 0.1,
+      staggerChildren: 0.15,
+      delayChildren: 0.05,
     },
   },
 };


### PR DESCRIPTION
Scaler logoen on scroll og gjorde avatar-bildene runde. Ser litt bedre ut når bildene på hovedstyre-section animeres inn.