### PR TITLE
Decode basic auth password

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -12,7 +12,7 @@ export function middleware(req: NextRequest) {
     if (!authValue) {
       return NextResponse.redirect("/");
     }
-    const [user, password] = window.atob(authValue).split(":");
+    const [user, password] = Buffer.from(authValue, "base64").toString().split(":");
 
     if (user?.toLowerCase() === "admin" && password === process.env.ADMIN_KEY) {
       return NextResponse.next();
@@ -20,5 +20,5 @@ export function middleware(req: NextRequest) {
   }
   url.pathname = "/";
 
-  return NextResponse.rewrite(url);
+  return NextResponse.redirect(url);
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "test:dev": "playwright test",
-    "test:install": "playwright install --with-deps"
+    "test:install": "playwright install --with-deps",
+    "test:report": "playwright show-report"
   },
   "devDependencies": {
     "@playwright/test": "^1.32.3"

--- a/tests/web/sanity.spec.ts
+++ b/tests/web/sanity.spec.ts
@@ -1,0 +1,7 @@
+import {expect, test} from "@playwright/test";
+
+test("/api/sanity redirect to /", async ({page}) => {
+  await page.goto("/api/sanity");
+
+  await expect(page).toHaveTitle("echo – Linjeforeningen for informatikk");
+});


### PR DESCRIPTION
Middleware bruker `Buffer.from()` til å lese auth. Om man ikke er authed redirect til `/`. Også lagt til test for dette.