### PR TITLE
Option for custom separator in breadcrumbs

### DIFF
--- a/apps/web/src/components/ui/breadcrumbs.tsx
+++ b/apps/web/src/components/ui/breadcrumbs.tsx
@@ -2,16 +2,23 @@ import React from "react";
 import Link from "next/link";
 import cn from "classnames";
 
+const DefaultSeparator = () => <span className="text-gray-400">/</span>;
+
 type BreadcrumbsRootProps = {
+  separator?: React.ReactNode;
   className?: string;
   children: React.ReactNode;
 };
 
-const BreadcrumbsRoot = ({className, children}: BreadcrumbsRootProps) => {
+const BreadcrumbsRoot = ({
+  separator = <DefaultSeparator />,
+  className,
+  children,
+}: BreadcrumbsRootProps) => {
   const childrenArray = React.Children.toArray(children);
 
   return (
-    <div className={cn("my-2", className)}>
+    <div className={cn("my-2 flex items-center gap-2", className)}>
       {childrenArray.map((child, index) => {
         // Don't render anything if the child is not a Breadcrumbs.Item
         if (!React.isValidElement(child) || child.type !== BreadcrumbsItem) {
@@ -27,7 +34,7 @@ const BreadcrumbsRoot = ({className, children}: BreadcrumbsRootProps) => {
         return (
           <React.Fragment key={index}>
             {child}
-            <span className="mx-2 text-gray-400">/</span>
+            {separator}
           </React.Fragment>
         );
       })}

--- a/apps/web/src/components/ui/breadcrumbs.tsx
+++ b/apps/web/src/components/ui/breadcrumbs.tsx
@@ -18,7 +18,7 @@ const BreadcrumbsRoot = ({
   const childrenArray = React.Children.toArray(children);
 
   return (
-    <div className={cn("my-2 flex items-center gap-2", className)}>
+    <div className={cn("my-2 flex items-center gap-2 text-sm md:text-base", className)}>
       {childrenArray.map((child, index) => {
         // Don't render anything if the child is not a Breadcrumbs.Item
         if (!React.isValidElement(child) || child.type !== BreadcrumbsItem) {


### PR DESCRIPTION
Gjør det mulig å ha egen separator i breadcrumbs.

```jsx
<Breadcrumbs separator={<ArrowRightIcon />}>
  <Breadcrumbs.Item to="/">Hjem</Breadcrumbs.Item>
  <Breadcrumbs.Item to={`/for-students/${group.groupType}`}>{title}</Breadcrumbs.Item>
  <Breadcrumbs.Item>{group.name}</Breadcrumbs.Item>
</Breadcrumbs>
```

blir til

![CleanShot 2023-04-17 at 00 15 04](https://user-images.githubusercontent.com/32321558/232345607-3bdf2756-2442-4326-8e21-14f98ea4081a.png)

Default ser slik ut

![CleanShot 2023-04-17 at 00 15 48](https://user-images.githubusercontent.com/32321558/232345637-9f89b85f-8e0a-424b-bccc-971bc9af21dd.png)
