### PR TITLE
Edge runtime compatible decode

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,6 +1,8 @@
+import {Buffer} from "node:buffer";
 import {NextResponse, type NextRequest} from "next/server";
 
 export const config = {
+  runtime: "experimental-edge",
   matcher: ["/api/sanity"],
 };
 export function middleware(req: NextRequest) {
@@ -12,6 +14,7 @@ export function middleware(req: NextRequest) {
     if (!authValue) {
       return NextResponse.redirect("/");
     }
+
     const [user, password] = Buffer.from(authValue, "base64").toString().split(":");
 
     if (user?.toLowerCase() === "admin" && password === process.env.ADMIN_KEY) {


### PR DESCRIPTION
Forrige var ikke gjort helt riktig heller, men nå skal middleware funke "on the edge". Må bare prefixe `buffer` med `node:`.

https://nextjs.org/docs/api-reference/edge-runtime