### PR TITLE
Update turbo script and add title to code blocks in docs

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -8,6 +8,7 @@
     "start": "sanity start",
     "build": "sanity build",
     "deploy": "sanity deploy",
+    "clean": "rm -rf node_modules .sanity dist",
     "deploy-graphql": "sanity graphql deploy",
     "todo:lint": "eslint '**/*.{js,ts,jsx,tsx}'",
     "todo:lint:fix": "eslint '**/*.{js,ts,jsx,tsx}' --fix",

--- a/apps/docs/docs/backend/trpc.md
+++ b/apps/docs/docs/backend/trpc.md
@@ -8,7 +8,7 @@ Vi bruker routers til å organisere tjenestene våre. Hver router kan ha sine eg
 
 Et eksempel på en tjeneste som returnerer "Hei, [Ditt navn]!" kan se slik ut:
 
-```tsx
+```tsx title="packages/api/src/routers/string.ts"
 import {z} from "zod";
 
 import {createTRPCRouter, publicProcedure} from "../trpc";
@@ -24,7 +24,7 @@ tRPC genererer deretter klientkoden din automatisk, slik at du kan kommunisere m
 
 Dette vil se slik ut i klienten (frontend):
 
-```tsx
+```tsx title="packages/web/src/pages/profile.tsx"
 import {api} from "@/utils/api";
 
 const ProfilePage = () => {

--- a/apps/docs/docs/sanity/dokumenter.md
+++ b/apps/docs/docs/sanity/dokumenter.md
@@ -8,8 +8,7 @@ For å opprette et dokument, må du først definere en dokumenttype. Dette gjør
 
 Her bruker vi hjelpe funksjonene `defineType` og `defineField` fra `sanity`-pakken for å definere dokumenttypen vår. Dette gjør at vi får auto-complete og type-sikkerhet når vi skriver dokumenttypen vår.
 
-```tsx
-// schemas/post.ts
+```tsx title="apps/cms/schemas/post.ts"
 import {defineField, defineType} from "sanity";
 
 export default defineType({
@@ -37,8 +36,7 @@ Dette vil opprette en ny dokumenttype som heter `post`. Denne dokumenttypen vil 
 
 For å referere til et dokument, kan du bruke `reference`-typen. Dette gjøres ved å definere et felt som har `reference`-typen, og referere til dokumenttypen du ønsker å referere til.
 
-```tsx
-// schemas/author.ts
+```tsx title="apps/cms/schemas/author.ts"
 import {defineField, defineType} from "sanity";
 
 export default defineType({
@@ -60,8 +58,7 @@ export default defineType({
 });
 ```
 
-```tsx
-// schemas/post.ts
+```tsx title="apps/cms/schemas/post.ts"
 import {defineField, defineType} from "sanity";
 
 export default defineType({

--- a/apps/docs/docs/sanity/groq.md
+++ b/apps/docs/docs/sanity/groq.md
@@ -26,21 +26,21 @@ Du kan også definere parametere for spørringen din. Dette gjøres ved å bruke
 
 For å gjøre disse spørringene i frontend-koden våres bruker vi `createClient`-funksjonen fra `next-sanity`-pakken for å opprette en klient som kan brukes til å spørre data fra Sanity.
 
-```tsx
+```tsx title="apps/web/src/lib/sanity.client.ts"
 import {createClient} from "next-sanity";
 
-const client = createClient({
+const sanityClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
   useCdn: process.env.NODE_ENV === "production",
 });
 
-export default client;
+export default sanityClient;
 ```
 
 Når vi har en klient, kan vi bruke `fetch`-funksjonen til å spørre data fra Sanity.
 
-```tsx
+```tsx title="apps/web/src/lib/post.ts"
 import client from "@/utils/sanity/client";
 
 const posts = await client.fetch(`*[_type == "post"]`);
@@ -50,7 +50,7 @@ const posts = await client.fetch(`*[_type == "post"]`);
 
 For å spørre data med parametere, kan vi bruke `fetch`-funksjonen til å spørre data fra Sanity.
 
-```tsx
+```tsx title="apps/web/src/lib/post.ts"
 import client from "@/utils/sanity/client";
 
 const posts = await client.fetch(`*[_type == $type]`, {
@@ -75,7 +75,7 @@ Denne spørringen vil returnere alle dokumenter av typen `post`, og inkludere fo
 
 Et praktisk eksempel vil være å spørre om alle innlegg og inkludere forfatterens navn og e-postadresse.
 
-```tsx
+```tsx title="apps/web/src/lib/post.ts"
 import client from "@/utils/sanity/client";
 
 const posts = await client.fetch(

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "clean:workspaces": "turbo run clean",
     "db:generate": "turbo run db:generate",
     "db:push": "turbo db:push db:generate",
-    "db:studio": "turbo run db:studio",
     "docker:up": "turbo run docker:up",
     "docker:down": "turbo run docker:down",
     "lint": "turbo run lint && manypkg check",

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test:dev": "playwright test",
     "test:install": "playwright install --with-deps",
-    "test:report": "playwright show-report"
+    "test:report": "playwright show-report",
+    "clean": "rm -rf node_modules playwright-report test-results"
   },
   "devDependencies": {
     "@playwright/test": "^1.32.3"

--- a/turbo.json
+++ b/turbo.json
@@ -32,9 +32,6 @@
     "test:dev": {
       "cache": false
     },
-    "test:e2e": {
-      "dependsOn": ["^build"]
-    },
     "lint": {},
     "type-check": {
       "dependsOn": ["^db:generate"],

--- a/turbo.json
+++ b/turbo.json
@@ -3,15 +3,10 @@
   "globalDependencies": ["**/.env"],
   "pipeline": {
     "db:generate": {
-      "inputs": ["prisma/schema.prisma"],
       "cache": false
     },
     "db:push": {
-      "inputs": ["prisma/schema.prisma"],
       "cache": false
-    },
-    "db:studio": {
-      "persistent": true
     },
     "docker:up": {
       "cache": false,
@@ -21,11 +16,12 @@
       "cache": false
     },
     "dev": {
+      "dependsOn": ["^db:generate"],
       "persistent": true,
       "cache": false
     },
     "build": {
-      "dependsOn": ["^build", "^db:generate"],
+      "dependsOn": ["^db:generate"],
       "outputs": [".next/**", ".sanity/**", ".docusaurus/**"]
     },
     "start": {


### PR DESCRIPTION
Oppdaterer turbo scriptsa litt, bare fjernet ting som er litt unødvendig.

Også lagt til titler på kodeblokkene i dokumentasjonen. Så slipper vi `// folder/file.ts` på toppen.

Orket ikke å lage to PRs på dette, så kjørte begge i en.