### PR TITLE
Add revalidate endpoint

### DIFF
--- a/apps/web/src/app/api/sanity/revalidate/route.ts
+++ b/apps/web/src/app/api/sanity/revalidate/route.ts
@@ -1,0 +1,17 @@
+import { revalidatePath } from "next/cache";
+
+import { withBasicAuth } from "@/lib/checks/with-basic-auth";
+
+export const POST = withBasicAuth(async (request: Request) => {
+  const payload = (await request.json()) as {
+    path?: string;
+  };
+
+  if (payload.path && typeof payload.path === "string") {
+    revalidatePath(payload.path);
+  } else {
+    revalidatePath("/");
+  }
+
+  return new Response("OK");
+});

--- a/apps/web/src/sanity/client.ts
+++ b/apps/web/src/sanity/client.ts
@@ -48,7 +48,7 @@ export async function sanityFetch<QueryResponse>({
   tags: Array<string>;
 }): Promise<QueryResponse> {
   return await client.fetch<QueryResponse>(query, params, {
-    cache: process.env.NODE_ENV === "production" ? "force-cache" : "no-store",
+    cache: "force-cache",
     next: {
       tags,
     },


### PR DESCRIPTION
## Why did you create this PR?

Det er ikke alltid ting blir revalidated riktig, f.eks idrettslag. Så vi trenger en å revalidere de.

## How did you solve the problem?

Dette er et `POST` endepunkt som kan ta inn en `{ path: string }` og revaliderer den pathen, om den ikke får noe json revaliderer den alt. Endepunktet er `/api/sanity/revalidate`.
