### PR TITLE
Semi dashboard for grupper og happenings

### DIFF
--- a/apps/web/src/app/(admin)/admin/grupper/page.tsx
+++ b/apps/web/src/app/(admin)/admin/grupper/page.tsx
@@ -4,17 +4,57 @@ import { Container } from "@/components/container";
 import { Heading } from "@/components/ui/heading";
 
 export default async function AdminGroupsPage() {
-  const groups = await db.query.groups.findMany();
+  const groups = await db.query.groups.findMany({
+    with: {
+      members: {
+        with: {
+          user: {
+            columns: {
+              name: true,
+            },
+          },
+        },
+      },
+      leaderUser: {
+        columns: {
+          name: true,
+        },
+      },
+    },
+  });
+
+  const g = groups.map((group) => {
+    return {
+      "id/slug": group.id,
+      name: group.name,
+      leader: group.leaderUser?.name ?? "Ingen",
+      members: group.members.map((member) => member.user.name),
+    };
+  });
 
   return (
     <Container>
-      <Heading className="mb-4">Grupper</Heading>
+      <Heading>Grupper</Heading>
 
-      <ul>
-        {groups.map((group) => (
-          <li key={group.id}>{group.name}</li>
-        ))}
-      </ul>
+      <div className="flex flex-col gap-2 py-4">
+        <p className="font-semibold">Oversikt over alle grupper og medlemmer.</p>
+
+        <p>
+          Denne siden kan brukes til debugging om noen sier at de ikke er medlem av en gruppe. Man
+          også bruke denne siden til å debugge {"id"} på en gruppe. For at en undergruppe skal kunne
+          se de som er påmeldt på arrangmentet sitt, så må {"id"} i databasen matche {"slug"} i
+          Sanity på undergruppen.
+        </p>
+
+        <p>
+          <i>(Ikke implementert enda)</i> Det er tenkt at en leder av en gruppe skal ha muligheten
+          til å legge til nye personer i de gruppene personen er leder av.
+        </p>
+      </div>
+
+      <code className="rounded-md bg-slate-100 p-2 font-mono">
+        <pre>{JSON.stringify(g, null, 2)}</pre>
+      </code>
     </Container>
   );
 }

--- a/apps/web/src/app/(admin)/admin/happenings/page.tsx
+++ b/apps/web/src/app/(admin)/admin/happenings/page.tsx
@@ -1,0 +1,68 @@
+import { db } from "@echo-webkom/db";
+
+import { Container } from "@/components/container";
+import { Heading } from "@/components/ui/heading";
+
+export default async function AdminHappeningsPage() {
+  const happenings = await db.query.happenings.findMany({
+    columns: {
+      slug: true,
+      title: true,
+    },
+    with: {
+      groups: {
+        with: {
+          group: {
+            columns: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const h = happenings.map((happening) => {
+    return {
+      "slug/id": happening.slug,
+      title: happening.title,
+      groups: happening.groups.map((group) => `${group.group.id}/${group.group.name}`),
+    };
+  });
+
+  return (
+    <Container>
+      <Heading>Happenings</Heading>
+
+      <div className="flex flex-col gap-2 py-4">
+        <p className="font-semibold">
+          Oversikt over alle happenings og gruppene som {"eier"} happeningen.
+        </p>
+
+        <p>
+          Navne på gruppene er{" "}
+          <i>
+            {"{id}"}/{"{navn}"}
+          </i>
+          .
+        </p>
+
+        <p>
+          Her kan du se at de riktige gruppene er knyttet til de riktige happeningene. Hvis en
+          undergruppe ikke har tilgang til å se påmeldte på et arrangement, så kan det være fordi at
+          {"id"} på en gruppe ikke matcher {"slug"} på gruppen i Sanity.
+        </p>
+
+        <p>
+          Om folk ikke får til å melde seg på en happening kan dette være fordi den ikke eksisterer
+          i databasen eller fordi slugen ikke matcher den i Sanity.
+        </p>
+      </div>
+
+      <code className="rounded-md bg-slate-100 p-2 font-mono">
+        <pre>{JSON.stringify(h, null, 2)}</pre>
+      </code>
+    </Container>
+  );
+}

--- a/apps/web/src/app/(admin)/admin/sidebar.tsx
+++ b/apps/web/src/app/(admin)/admin/sidebar.tsx
@@ -22,8 +22,16 @@ const adminRoutes = [
     label: "Brukere",
   },
   {
+    href: "/admin/happenings",
+    label: "Happenings",
+  },
+  {
     href: "/admin/grupper",
     label: "Grupper",
+  },
+  {
+    href: "/admin/studieretninger",
+    label: "Studieretninger",
   },
 ];
 

--- a/apps/web/src/app/(admin)/admin/studieretninger/page.tsx
+++ b/apps/web/src/app/(admin)/admin/studieretninger/page.tsx
@@ -1,0 +1,26 @@
+import { db } from "@echo-webkom/db";
+
+import { Container } from "@/components/container";
+import { Heading } from "@/components/ui/heading";
+
+export default async function AdminDegreePage() {
+  const degrees = await db.query.degrees.findMany();
+
+  return (
+    <Container>
+      <Heading>Studieretninger</Heading>
+
+      <div className="flex flex-col gap-2 py-4">
+        <p className="font-semibold">Oversikt over alle studieretninger</p>
+
+        <p>
+          <i>(Ikke implementert enda)</i> Burde være mulig å legge til flere her.
+        </p>
+      </div>
+
+      <code className="rounded-md bg-slate-100 p-2 font-mono">
+        <pre>{JSON.stringify(degrees, null, 2)}</pre>
+      </code>
+    </Container>
+  );
+}

--- a/packages/db/schemas/groups.ts
+++ b/packages/db/schemas/groups.ts
@@ -20,7 +20,7 @@ export const groups = pgTable(
 );
 
 export const groupsRelations = relations(groups, ({ one, many }) => ({
-  leader: one(users, {
+  leaderUser: one(users, {
     fields: [groups.leader],
     references: [users.id],
     relationName: "group_leader",


### PR DESCRIPTION
Semi-dashboard for oversikt over alle grupper, happenings og studieretninger. Burde bli designet bedre, men er ment for lett debugging av ting fra webkom sin side. 

Eksempel på hvordan de ser ut vist under. Kjører typ JSON-format.

![CleanShot 2023-10-20 at 16 19 41@2x](https://github.com/echo-webkom/new-echo-web-monorepo/assets/32321558/73e95195-1f66-423f-81f0-e47fb963fdd8)
