### PR TITLE
Remove prose from markdown

### DIFF
--- a/apps/web/src/app/(default)/for-studenter/innlegg/[slug]/page.tsx
+++ b/apps/web/src/app/(default)/for-studenter/innlegg/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { Container } from "@/components/container";
 import { Markdown } from "@/components/markdown";
 import { Heading } from "@/components/ui/heading";
+import { isBoard } from "@/lib/is-board";
 import { fetchPostBySlug, fetchPostParams, type Author } from "@/sanity/posts";
 import { urlFor } from "@/utils/image-builder";
 
@@ -76,7 +77,7 @@ function Authors({ authors }: { authors: Array<Author> }) {
               </div>
             )}
 
-            <p className="text-xl">{author.name}</p>
+            <p className="text-xl">{isBoard(author.name) ? "Hovedstyret" : author.name}</p>
           </div>
         ))}
       </div>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -16,35 +16,68 @@ export function Markdown({ className, content }: MarkdownProps) {
   }
 
   return (
-    <ReactMarkdown
-      className={cn("prose", "md:prose-xl", className)}
-      components={{
-        a: ({ children, href }) => {
-          // TODO: Add external link icon and behavior
-          return (
-            <Link
-              className="transition-colors duration-200 after:content-['_↗'] hover:text-blue-500"
-              href={href ?? ""}
-            >
-              {children}
-            </Link>
-          );
-        },
-        img: ({ src, alt }) => {
-          return (
-            <Image
-              src={src ?? ""}
-              alt={alt ?? ""}
-              width="600"
-              height="400"
-              className="mx-auto h-auto max-w-full"
-            />
-          );
-        },
-      }}
-      remarkPlugins={[remarkGfm]}
-    >
-      {content}
-    </ReactMarkdown>
+    <article className={cn("max-w-3xl text-xl text-gray-800", className)}>
+      <ReactMarkdown
+        components={{
+          p: ({ children }) => {
+            return <p className="py-4 leading-8">{children}</p>;
+          },
+          ul: ({ children }) => {
+            return <ul className="list-disc py-4 pl-8">{children}</ul>;
+          },
+          ol: ({ children }) => {
+            return <ol className="list-decimal py-4 pl-8">{children}</ol>;
+          },
+          li: ({ children }) => {
+            return <li className="py-1">{children}</li>;
+          },
+          a: ({ children, href }) => {
+            const isExternal = href?.startsWith("http");
+            const classNames = cn(
+              "transition-colors underline font-medium duration-200 after:content-['_↗'] hover:text-blue-500",
+              {
+                "after:content-['_↗']": isExternal,
+              },
+            );
+
+            if (isExternal) {
+              return (
+                <a
+                  className={classNames}
+                  href={href ?? ""}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {children}
+                </a>
+              );
+            }
+
+            return (
+              <Link className={classNames} href={href ?? ""}>
+                {children}
+              </Link>
+            );
+          },
+          img: ({ src, alt }) => {
+            return (
+              <Image
+                src={src ?? ""}
+                alt={alt ?? ""}
+                width="600"
+                height="400"
+                className="mx-auto h-auto max-w-full"
+              />
+            );
+          },
+          hr: () => {
+            return <hr className="my-8 border-t-gray-300" />;
+          },
+        }}
+        remarkPlugins={[remarkGfm]}
+      >
+        {content}
+      </ReactMarkdown>
+    </article>
   );
 }

--- a/apps/web/src/components/post-preview.tsx
+++ b/apps/web/src/components/post-preview.tsx
@@ -3,6 +3,7 @@ import { format } from "date-fns";
 import nb from "date-fns/locale/nb";
 import removeMd from "remove-markdown";
 
+import { isBoard } from "@/lib/is-board";
 import { type Post } from "@/sanity/posts";
 import { cn } from "@/utils/cn";
 
@@ -17,9 +18,7 @@ export function PostPreview({ post, withBorder = false, className }: PostPreview
     <Link
       href={`/for-studenter/innlegg/${post.slug}`}
       className={cn(
-        "flex h-full flex-col gap-1 rounded-lg p-5",
-        "hover:bg-muted",
-        "shadow-lg transition-colors duration-200 ease-in-out",
+        "flex h-full flex-col gap-1 rounded-lg p-5 shadow-lg transition-colors duration-200 ease-in-out hover:bg-muted",
         withBorder && "border",
         className,
       )}
@@ -40,7 +39,9 @@ export function PostPreview({ post, withBorder = false, className }: PostPreview
       {post.authors && (
         <p>
           <span className="font-semibold">Skrevet av:</span>{" "}
-          {post.authors.map((author) => author.name).join(", ")}
+          {post.authors
+            .map((author) => (isBoard(author.name) ? "Hovedstyret" : author.name))
+            .join(", ")}
         </p>
       )}
     </Link>

--- a/apps/web/src/lib/is-board.ts
+++ b/apps/web/src/lib/is-board.ts
@@ -1,0 +1,16 @@
+export function isBoard(str: string) {
+  if (!str.includes("/")) {
+    return false;
+  }
+
+  const [start, end] = str.split("/");
+
+  const startIsNumber = !isNaN(Number(start));
+  const endIsNumber = !isNaN(Number(end));
+
+  if (startIsNumber && endIsNumber) {
+    return true;
+  }
+
+  return false;
+}

--- a/apps/web/src/sanity/posts/index.ts
+++ b/apps/web/src/sanity/posts/index.ts
@@ -69,10 +69,11 @@ export async function fetchPosts(n: number) {
  * @returns an object with the posts and if there are more posts to retrieve
  */
 export async function fetchPostsByPage(page: number, pageSize = 10) {
+  const start = (page - 1) * pageSize;
+  const end = page * pageSize;
+
   const query = groq`
-*[_type == "post" && !(_id in path('drafts.**'))][${(page - 1) * pageSize}...${
-    page * pageSize
-  }] | order(_createdAt desc) {
+*[_type == "post" && !(_id in path('drafts.**'))]| order(_createdAt desc) {
   _id,
   _createdAt,
   _updatedAt,
@@ -85,12 +86,12 @@ export async function fetchPostsByPage(page: number, pageSize = 10) {
   },
   image,
   body
-}
+}[$start...$end]
   `;
 
   const params = {
-    page,
-    pageSize,
+    start,
+    end,
   };
 
   const result = await sanityFetch<Array<Post>>({


### PR DESCRIPTION
Fjerner tailwind sin prose klasse og bruker egne komponenter. Dette er for å ha mer kontrol over hvordan ting blir stylet.
