### PR TITLE
Deactivate preview db workflow

### DIFF
--- a/.github/workflows/destroy-preview.yaml
+++ b/.github/workflows/destroy-preview.yaml
@@ -1,9 +1,9 @@
 name: Destroy preview
 
-on:
-  pull_request:
-    branches: [main]
-    types: [closed]
+# on:
+#   pull_request:
+#     branches: [main]
+#     types: [closed]
 
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,8 +1,8 @@
 name: Deploy preview
 
-on:
-  pull_request:
-    types: [opened, synchronize]
+# on:
+#   pull_request:
+#     types: [opened, synchronize]
 
 permissions:
   id-token: write


### PR DESCRIPTION
Deaktiverer workflow for preview db siden vi trenger det egentlig ikke, og det koster oss egentlig bare penger per nå. Best om vi finner en måte der vi faktisk har bruk for databasen, legge til credential login som vi har på `echo-webkom/echo-web`.
