### PR TITLE
Links to eventpage from happening-preview-box

### DIFF
--- a/apps/web/src/components/happening-preview-box.tsx
+++ b/apps/web/src/components/happening-preview-box.tsx
@@ -27,12 +27,19 @@ const happeningTypeToString: Record<HappeningType, string> = {
   BEDPRES: "bedriftspresentasjoner",
 };
 
+const typeToLink: Record<HappeningType, string> = {
+  EVENT: "/for-studenter/arrangementer?type=arrangement",
+  BEDPRES: "/for-studenter/arrangementer?type=bedpres",
+};
+
 export function HappeningPreviewBox({ type, happenings }: HappeningPreviewBoxProps) {
   return (
     <div>
-      <h2 className="text-center text-xl font-semibold md:text-3xl">
-        {capitalize(happeningTypeToString[type])}
-      </h2>
+      <Link href={typeToLink[type]}>
+        <h2 className="text-center text-xl font-semibold md:text-3xl">
+          {capitalize(happeningTypeToString[type])}
+        </h2>
+      </Link>
 
       <hr className="my-3" />
 


### PR DESCRIPTION
La til to linker til happening preview box, som kan benyttes på landing pagen. "Arrangementer" linker til eventpage sortert etter arrangementer, og "Bedriftspresentasjoner" linker til eventpage sortert etter bedpres. 