### PR TITLE
Make post chip colorful

### DIFF
--- a/apps/web/src/app/(default)/content.tsx
+++ b/apps/web/src/app/(default)/content.tsx
@@ -39,7 +39,7 @@ export async function Content() {
 
         <hr />
 
-        <ul className="grid grid-cols-1 gap-x-3 gap-y-5 lg:grid-cols-2">
+        <ul className="grid grid-cols-1 gap-x-3 gap-y-5 py-4 lg:grid-cols-2">
           {posts.map((post) => (
             <li key={post._id}>
               <PostPreview post={post} className="shadow-none" />

--- a/apps/web/src/app/(default)/for-studenter/innlegg/page.tsx
+++ b/apps/web/src/app/(default)/for-studenter/innlegg/page.tsx
@@ -35,10 +35,10 @@ export default async function PostsOverviewPage({ searchParams }: Props) {
   const { posts, hasMore } = await getData(page);
 
   return (
-    <Container className="space-y-4">
+    <Container className="space-y-8">
       <Heading>Innlegg</Heading>
 
-      <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+      <div className="grid grid-cols-1 gap-x-5 gap-y-8 lg:grid-cols-2">
         {posts.map((post) => (
           <div key={post._id}>
             <PostPreview post={post} withBorder />

--- a/apps/web/src/app/(default)/page.tsx
+++ b/apps/web/src/app/(default)/page.tsx
@@ -25,7 +25,10 @@ export default async function HomePage() {
               Vi i echo jobber med å gjøre studiehverdagen for informatikkstudenter bedre ved å
               arrangere sosiale og faglige arrangementer.
               <br /> Les mer{" "}
-              <Link className="font-semibold" href="/om/echo">
+              <Link
+                className="font-semibold underline underline-offset-2 hover:text-primary"
+                href="/om/echo"
+              >
                 her.
               </Link>
             </p>

--- a/apps/web/src/components/post-preview.tsx
+++ b/apps/web/src/components/post-preview.tsx
@@ -6,6 +6,7 @@ import removeMd from "remove-markdown";
 import { isBoard } from "@/lib/is-board";
 import { type Post } from "@/sanity/posts";
 import { cn } from "@/utils/cn";
+import { Chip } from "./typography/chip";
 
 type PostPreviewProps = {
   post: Post;
@@ -15,35 +16,34 @@ type PostPreviewProps = {
 
 export function PostPreview({ post, withBorder = false, className }: PostPreviewProps) {
   return (
-    <Link
-      href={`/for-studenter/innlegg/${post.slug}`}
-      className={cn(
-        "flex h-full flex-col gap-1 rounded-lg p-5 shadow-lg transition-colors duration-200 ease-in-out hover:bg-muted",
-        withBorder && "border",
-        className,
-      )}
-    >
-      <h3 className="line-clamp-2 flex gap-2 text-xl font-semibold md:text-2xl">{post.title}</h3>
+    <Link href={`/for-studenter/innlegg/${post.slug}`}>
+      <div
+        className={cn(
+          "relative flex h-full flex-col gap-1 rounded-lg p-5 shadow-lg transition-colors duration-200 ease-in-out hover:bg-muted",
+          withBorder && "border",
+          className,
+        )}
+      >
+        <h3 className="line-clamp-2 flex gap-2 text-xl font-semibold md:text-2xl">{post.title}</h3>
 
-      <p>
-        Publisert:{" "}
-        {format(new Date(post._createdAt), "d. MMMM yyyy", {
-          locale: nb,
-        })}
-      </p>
-
-      <hr />
-
-      <p className="my-2 line-clamp-3 italic">{removeMd(post.body)}</p>
-
-      {post.authors && (
-        <p>
-          <span className="font-semibold">Skrevet av:</span>{" "}
-          {post.authors
-            .map((author) => (isBoard(author.name) ? "Hovedstyret" : author.name))
-            .join(", ")}
+        <p className="text-sm text-gray-500 sm:absolute sm:right-2 sm:top-2">
+          {format(new Date(post._createdAt), "d. MMMM yyyy", {
+            locale: nb,
+          })}
         </p>
-      )}
+
+        <p className="my-2 line-clamp-3 italic">{removeMd(post.body)}</p>
+
+        {post.authors && (
+          <div className="flex flex-row flex-wrap items-center gap-1 sm:absolute sm:-bottom-3 sm:left-4">
+            {post.authors.map((author) => (
+              <Chip className="bg-secondary text-secondary-foreground" key={author._id}>
+                {isBoard(author.name) ? "Hovedstyret" : author.name}
+              </Chip>
+            ))}
+          </div>
+        )}
+      </div>
     </Link>
   );
 }


### PR DESCRIPTION
## Why did you create this PR?

Måten vi viste forfattere på var litt svart-hvitt og kjedelig. Tror denne er litt kulere?

## How did you solve the problem?

Bruke `<Chip />` til å vise forfattere på venstre kant av previewen.

![CleanShot 2023-12-06 at 22 50 59@2x](https://github.com/echo-webkom/new-echo-web-monorepo/assets/32321558/dd2bff63-820b-48cb-bbd0-d98c503dd3eb)

